### PR TITLE
entrypoint: echo rpc auth token for dev testing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,6 +47,8 @@ export CELESTIA_CUSTOM=test:$GENESIS
 echo $CELESTIA_CUSTOM
 
 celestia bridge init --node.store /bridge
+export CELESTIA_NODE_AUTH_TOKEN=$(celestia bridge auth admin --node.store /bridge)
+echo "WARNING: Keep this auth token secret **DO NOT** log this auth token outside of development. CELESTIA_NODE_AUTH_TOKEN=$CELESTIA_NODE_AUTH_TOKEN"
 celestia bridge start \
   --node.store /bridge --gateway \
   --core.ip 127.0.0.1 \


### PR DESCRIPTION
## Overview

This PR adds an `echo` for the node rpc auth token so that clients can use it for testing during development.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
