### PR TITLE
Clean up Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Local Celestia Devnet
 
-This repo provides a docker image that allows developers to spin up a local
+This repo provides a Docker image that allows developers to spin up a local
 devnet node for testing without depending on the network or service.
 
-## To run the docker image from ghcr.io
+## To run the Docker image from ghcr.io
 
 ```bash
-docker run --platform linux/amd64 \
+Docker run --platform linux/amd64 \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
 
-## To build and run the docker image
+## To build and run the Docker image
 
 First, clone the repository:
 
@@ -25,16 +25,16 @@ Change into the directory:
 cd local-celestia-devnet/
 ```
 
-To build the docker image:
+To build the Docker image:
 
 ```bash
-docker build . -t celestia-local-devnet
+Docker build . -t celestia-local-devnet
 ```
 
-To run the docker container:
+To run the Docker container:
 
 ```bash
-docker run --platform linux/amd64 \
+Docker run --platform linux/amd64 \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the docker image from ghcr.io
 
 ```bash
-docker run --platform linux/amd64 -p 26657:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:latest
+docker run --platform linux/amd64 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 ghcr.io/rollkit/local-celestia-devnet:latest
 ```
 
 ## To build and run the docker image
@@ -32,7 +32,7 @@ docker build . -t celestia-local-devnet
 To run the docker container:
 
 ```bash
-docker run --platform linux/amd64 -p 26657:26657 -p 26659:26659 celestia-local-devnet
+docker run --platform linux/amd64 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 celestia-local-devnet
 ```
 
 Test that the RPC server is up:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the Docker image from ghcr.io
 
 ```bash
-Docker run --platform linux/amd64 \
+docker run --platform linux/amd64 \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
@@ -28,13 +28,13 @@ cd local-celestia-devnet/
 To build the Docker image:
 
 ```bash
-Docker build . -t celestia-local-devnet
+docker build . -t celestia-local-devnet
 ```
 
 To run the Docker container:
 
 ```bash
-Docker run --platform linux/amd64 \
+docker run --platform linux/amd64 \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the docker image from ghcr.io
 
 ```bash
-docker run --platform linux/amd64 -p 26657:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:v0.8.2
+docker run --platform linux/amd64 -p 26657:26657 -p 26659:26659 ghcr.io/rollkit/local-celestia-devnet:latest
 ```
 
 ## To build and run the docker image

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run \
     celestia-local-devnet
 ```
 
-Test that the RPC server is up:
+Test that the HTTP gateway server is up:
 
 ```bash
 curl -X GET http://127.0.0.1:26659/head

--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ Test that the RPC server is up:
 ```bash
 curl -X GET http://127.0.0.1:26659/head
 ```
+
+## Exposed Ports
+
+| Port  | Protocol | Address   | Description |
+|-------|----------|-----------|-------------|
+| 26657 | HTTP     | 127.0.0.1 | RPC         |
+| 26658 | HTTP     | 127.0.0.1 | RPC         |
+| 26659 | HTTP     | 127.0.0.1 | REST        |
+| 9090  | HTTP     | 0.0.0.0   | gRPC        |
+
+You can also find a section on port usage in the
+[`celestia-app` tutorial](https://docs.celestia.org/nodes/celestia-app/#ports)
+and the node
+[troubleshooting section](https://docs.celestia.org/nodes/celestia-node-troubleshooting/#ports).

--- a/README.md
+++ b/README.md
@@ -47,14 +47,17 @@ curl -X GET http://127.0.0.1:26659/head
 
 ## Exposed Ports
 
-| Port  | Protocol | Address   | Description |
-|-------|----------|-----------|-------------|
-| 26657 | HTTP     | 127.0.0.1 | RPC         |
-| 26658 | HTTP     | 127.0.0.1 | RPC         |
-| 26659 | HTTP     | 127.0.0.1 | REST        |
-| 9090  | HTTP     | 0.0.0.0   | gRPC        |
+| Port  | Protocol | Address   | Description | Node Type                               |
+|-------|----------|-----------|-------------|-----------------------------------------|
+| 26657 | HTTP     | 127.0.0.1 | RPC         | Consensus (e.g `celestia-app`)          |
+| 26658 | HTTP     | 127.0.0.1 | RPC         | Data Availability (e.g `celestia-node`) |
+| 26659 | HTTP     | 127.0.0.1 | REST        | Data Availability (e.g `celestia-node`) |
+| 9090  | HTTP     | 0.0.0.0   | gRPC        | Consensus (e.g `celestia-app`)          |
 
 You can also find a section on port usage in the
 [`celestia-app` tutorial](https://docs.celestia.org/nodes/celestia-app/#ports)
 and the node
 [troubleshooting section](https://docs.celestia.org/nodes/celestia-node-troubleshooting/#ports).
+
+For information about the different node types, see
+[here](https://docs.celestia.org/nodes/overview/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ devnet node for testing without depending on the network or service.
 ## To run the docker image from ghcr.io
 
 ```bash
-docker run --platform linux/amd64 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 ghcr.io/rollkit/local-celestia-devnet:latest
+docker run --platform linux/amd64 \
+    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    ghcr.io/rollkit/local-celestia-devnet:latest
 ```
 
 ## To build and run the docker image
@@ -32,7 +34,9 @@ docker build . -t celestia-local-devnet
 To run the docker container:
 
 ```bash
-docker run --platform linux/amd64 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 celestia-local-devnet
+docker run --platform linux/amd64 \
+    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    celestia-local-devnet
 ```
 
 Test that the RPC server is up:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the Docker image from ghcr.io
 
 ```bash
-docker run --platform linux/amd64 \
+docker run \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
@@ -34,7 +34,7 @@ docker build . -t celestia-local-devnet
 To run the Docker container:
 
 ```bash
-docker run --platform linux/amd64 \
+docker run \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```


### PR DESCRIPTION
Hey! I ended up running into an couple of issues when using the provided Docker command
since it was using a) an old version of the Celestia node and b) not forwarding the port
used by the JSON-RPC API.

I've updated the README accordingly.

---

On a sidenote, what's the difference between port 26657 and 26658. In the docs it says
both are for RPC but I don't see 26657 used anywhere.

Thanks!
