### PR TITLE
feat: add -t and -i flags to docker run command so that docker contai…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker run -d -t -i \
 To stop the container when you are attached to the container, you can use
 `Ctrl+C` to stop the container.
 
-To stop the container when ou are detached from the container, you can use the
+To stop the container when you are detached from the container, you can use the
 `docker ps` command to find the container ID:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker build . -t celestia-local-devnet
 To run the Docker container:
 
 ```bash
-docker run \
+docker run -t -i \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the Docker image from ghcr.io
 
 ```bash
-docker run \
+docker run -t -i \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the Docker image from ghcr.io
 
 ```bash
-docker run -t -i -d \
+docker run -t -i \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
@@ -34,7 +34,7 @@ docker build . -t celestia-local-devnet
 To run the Docker container:
 
 ```bash
-docker run -t -i -d \
+docker run -t -i \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```
@@ -43,6 +43,41 @@ Test that the HTTP gateway server is up:
 
 ```bash
 curl -X GET http://127.0.0.1:26659/head
+```
+
+## Running a Detached Container
+
+If you would like the run the container in the background, you can use the
+`-d` flag:
+
+```bash
+docker run -d -t -i \
+    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    celestia-local-devnet
+```
+
+## Stopping the Container
+
+To stop the container when you are attached to the container, you can use
+`Ctrl+C` to stop the container.
+
+To stop the container when ou are detached from the container, you can use the
+`docker ps` command to find the container ID:
+
+```bash
+docker ps
+```
+
+Then, use the `docker stop` command to stop the container:
+
+```bash
+docker stop <container-id>
+```
+
+To remove the container, use the `docker rm` command to remove the container:
+
+```bash
+docker rm <container-id>
 ```
 
 ## Exposed Ports

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ devnet node for testing without depending on the network or service.
 ## To run the Docker image from ghcr.io
 
 ```bash
-docker run -t -i \
+docker run -t -i -d \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
@@ -34,7 +34,7 @@ docker build . -t celestia-local-devnet
 To run the Docker container:
 
 ```bash
-docker run -t -i \
+docker run -t -i -d \
     -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```


### PR DESCRIPTION
…ner can be stopped with crtl c

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Close #65 

REF: https://forums.docker.com/t/docker-run-cannot-be-killed-with-ctrl-c/13108/4

```
  -i, --interactive                    Keep STDIN open even if not attached
  -t, --tty                            Allocate a pseudo-TTY
```
