### PR TITLE
enable grpc in celestia-appd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ mkdir -p $NODE_PATH/keys
 cp -r $APP_PATH/keyring-test/ $NODE_PATH/keys/keyring-test/
 
 # Start the celestia-app
-celestia-appd start &
+celestia-appd start --grpc.enable &
 
 # Try to get the genesis hash. Usually first request returns an empty string (port is not open, curl fails), later attempts
 # returns "null" if block was not yet produced.
@@ -78,7 +78,5 @@ export CELESTIA_NODE_AUTH_TOKEN=$(celestia bridge auth admin --node.store ${NODE
 echo "WARNING: Keep this auth token secret **DO NOT** log this auth token outside of development. CELESTIA_NODE_AUTH_TOKEN=$CELESTIA_NODE_AUTH_TOKEN"
 celestia bridge start \
   --node.store $NODE_PATH --gateway \
-  # --core.ip 127.0.0.1 \
-  # --core.ip rpc-mocha.pops.one:26657 \
-  # --core.rpc.port 9090 \
+  --core.ip 127.0.0.1 \
   --keyring.accname validator


### PR DESCRIPTION
Fixes 
```
'blob.Submit': runtime error: invalid memory address or nil pointer dereference
github.com/filecoin-project/go-jsonrpc.doCall.func1
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/handler.go:276
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:914
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:261
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:861
github.com/celestiaorg/celestia-node/state.(*CoreAccessor).getMinGasPrice
	/src/state/core_access.go:555
github.com/celestiaorg/celestia-node/state.(*CoreAccessor).SubmitPayForBlob
	/src/state/core_access.go:219
github.com/celestiaorg/celestia-node/blob.(*Service).Submit
	/src/blob/service.go:80
reflect.Value.call
	/usr/local/go/src/reflect/value.go:596
reflect.Value.Call
	/usr/local/go/src/reflect/value.go:380
github.com/filecoin-project/go-jsonrpc/auth.PermissionedProxy.func1
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/auth/auth.go:62
github.com/celestiaorg/celestia-node/nodebuilder/blob.(*API).Submit
	/src/nodebuilder/blob/blob.go:42
reflect.Value.call
	/usr/local/go/src/reflect/value.go:596
reflect.Value.Call
	/usr/local/go/src/reflect/value.go:380
github.com/filecoin-project/go-jsonrpc.doCall
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/handler.go:280
github.com/filecoin-project/go-jsonrpc.(*handler).handle
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/handler.go:424
github.com/filecoin-project/go-jsonrpc.(*handler).handleReader
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/handler.go:268
github.com/filecoin-project/go-jsonrpc.(*RPCServer).ServeHTTP
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/server.go:104
github.com/filecoin-project/go-jsonrpc/auth.(*Handler).ServeHTTP
	/go/pkg/mod/github.com/filecoin-project/go-jsonrpc@v0.3.1/auth/handler.go:47
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:2938
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:2009
```
as reported in https://app.warp.dev/block/cOOmG972fN4YynJPhkxm1e by @jcstein 