### PR TITLE
docker: replace celestia with celestia-da

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/celestiaorg/celestia-app:v1.4.0 AS celestia-app
 
-FROM ghcr.io/celestiaorg/celestia-node:v0.12.0
+FROM opcelestia/celestia-da:v0.12.0
 
 USER root
 
@@ -17,6 +17,6 @@ COPY --from=celestia-app /bin/celestia-appd /bin/
 
 COPY entrypoint.sh /opt/entrypoint.sh
 
-EXPOSE 26657 26658 26659 9090
+EXPOSE 26650 26657 26658 26659 9090
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ USER root
 RUN apk --no-cache add \
         curl \
         jq \
+        openssl \
     && mkdir /bridge \
     && chown celestia:celestia /bridge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/celestiaorg/celestia-app:v1.4.0 AS celestia-app
 
-FROM opcelestia/celestia-da:v0.12.0
+FROM ghcr.io/rollkit/celestia-da:v0.12.1-rc0
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ docker rm <container-id>
 | 26659 | HTTP     | 127.0.0.1 | REST        | Data Availability (e.g `celestia-node`) |
 | 9090  | HTTP     | 0.0.0.0   | gRPC        | Consensus (e.g `celestia-app`)          |
 
+## Environment Variables
+
+| Variable               | Description                     | Default            |
+|------------------------|---------------------------------|--------------------|
+| CELESTIA_NAMESPACE     | Namespace to use for DA Service | Randomly generated |
+
 You may also find these docs helpful:
 
 - [celestia-app ports](https://docs.celestia.org/nodes/celestia-app/#ports)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For information about the different node types, see
 
 ```bash
 docker run -t -i \
-    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     ghcr.io/rollkit/local-celestia-devnet:latest
 ```
 
@@ -41,7 +41,7 @@ To run the Docker container:
 
 ```bash
 docker run -t -i \
-    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```
 
@@ -58,7 +58,7 @@ If you would like the run the container in the background, you can use the
 
 ```bash
 docker run -d -t -i \
-    -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
+    -p 26650:26650 -p 26657:26657 -p 26658:26658 -p 26659:26659 -p 9090:9090 \
     celestia-local-devnet
 ```
 
@@ -90,6 +90,7 @@ docker rm <container-id>
 
 | Port  | Protocol | Address   | Description | Node Type                               |
 |-------|----------|-----------|-------------|-----------------------------------------|
+| 26650 | gRPC     | 127.0.0.1 | gRPC        | Data Availability Service               |
 | 26657 | HTTP     | 127.0.0.1 | RPC         | Consensus (e.g `celestia-app`)          |
 | 26658 | HTTP     | 127.0.0.1 | RPC         | Data Availability (e.g `celestia-node`) |
 | 26659 | HTTP     | 127.0.0.1 | REST        | Data Availability (e.g `celestia-node`) |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,12 +71,17 @@ while [ "${#GENESIS}" -le 4 -a $CNT -ne $MAX ]; do
 done
 
 export CELESTIA_CUSTOM=test:$GENESIS
-echo $CELESTIA_CUSTOM
+echo "$CELESTIA_CUSTOM"
+
+if [ -z "$CELESTIA_NAMESPACE" ]; then
+    CELESTIA_NAMESPACE=0000$(openssl rand -hex 8)
+fi
+echo CELESTIA_NAMESPACE="$CELESTIA_NAMESPACE"
 
 celestia-da bridge init --node.store /home/celestia/bridge
 celestia-da bridge start \
   --node.store $NODE_PATH --gateway \
   --core.ip 127.0.0.1 \
   --keyring.accname validator \
-  --da.grpc.namespace "000008e5f679bf7116cb" \
+  --da.grpc.namespace "$CELESTIA_NAMESPACE" \
   --da.grpc.listen "0.0.0.0:26650"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,8 +70,11 @@ while [ "${#GENESIS}" -le 4 -a $CNT -ne $MAX ]; do
 	sleep 1
 done
 
-CELESTIA_CUSTOM=test:$GENESIS celestia-da bridge init --node.store /home/celestia/bridge
-CELESTIA_CUSTOM=test:$GENESIS celestia-da bridge start \
+export CELESTIA_CUSTOM=test:$GENESIS
+echo $CELESTIA_CUSTOM
+
+celestia-da bridge init --node.store /home/celestia/bridge
+celestia-da bridge start \
   --node.store $NODE_PATH --gateway \
   --core.ip 127.0.0.1 \
   --keyring.accname validator \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,16 +70,10 @@ while [ "${#GENESIS}" -le 4 -a $CNT -ne $MAX ]; do
 	sleep 1
 done
 
-export CELESTIA_CUSTOM=test:$GENESIS
-echo $CELESTIA_CUSTOM
-
-celestia-da bridge init --node.store /home/celestia/bridge
-export CELESTIA_NODE_AUTH_TOKEN=$(celestia-da bridge auth admin --node.store ${NODE_PATH})
-echo "WARNING: Keep this auth token secret **DO NOT** log this auth token outside of development. CELESTIA_NODE_AUTH_TOKEN=$CELESTIA_NODE_AUTH_TOKEN"
-celestia-da bridge start \
+CELESTIA_CUSTOM=test:$GENESIS celestia-da bridge init --node.store /home/celestia/bridge
+CELESTIA_CUSTOM=test:$GENESIS celestia-da bridge start \
   --node.store $NODE_PATH --gateway \
   --core.ip 127.0.0.1 \
   --keyring.accname validator \
-  --grpc.token "$CELESTIA_NODE_AUTH_TOKEN" \
-  --grpc.namespace "000008e5f679bf7116cb" \
-  --grpc.listen "0.0.0.0:26650"
+  --da.grpc.namespace "000008e5f679bf7116cb" \
+  --da.grpc.listen "0.0.0.0:26650"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,10 +73,13 @@ done
 export CELESTIA_CUSTOM=test:$GENESIS
 echo $CELESTIA_CUSTOM
 
-celestia bridge init --node.store /home/celestia/bridge
-export CELESTIA_NODE_AUTH_TOKEN=$(celestia bridge auth admin --node.store ${NODE_PATH})
+celestia-da bridge init --node.store /home/celestia/bridge
+export CELESTIA_NODE_AUTH_TOKEN=$(celestia-da bridge auth admin --node.store ${NODE_PATH})
 echo "WARNING: Keep this auth token secret **DO NOT** log this auth token outside of development. CELESTIA_NODE_AUTH_TOKEN=$CELESTIA_NODE_AUTH_TOKEN"
-celestia bridge start \
+celestia-da bridge start \
   --node.store $NODE_PATH --gateway \
   --core.ip 127.0.0.1 \
-  --keyring.accname validator
+  --keyring.accname validator \
+  --grpc.token "$CELESTIA_NODE_AUTH_TOKEN" \
+  --grpc.namespace "000008e5f679bf7116cb" \
+  --grpc.listen "127.0.0.1:26650"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,4 +82,4 @@ celestia-da bridge start \
   --keyring.accname validator \
   --grpc.token "$CELESTIA_NODE_AUTH_TOKEN" \
   --grpc.namespace "000008e5f679bf7116cb" \
-  --grpc.listen "127.0.0.1:26650"
+  --grpc.listen "0.0.0.0:26650"


### PR DESCRIPTION
## Overview

Fixes #74 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced gRPC service on port 26650 for the Data Availability Service.
  - Updated Docker base image to enhance application stability and performance.

- **Documentation**
  - Updated README.md with new port mappings and environment variable usage instructions.

- **Refactor**
  - Modified entrypoint script to initialize and start the `celestia-da` bridge with new parameters for improved service integration.

- **Chores**
  - Adjusted Dockerfile to expose additional port and include necessary package installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->