### PR TITLE
docker: expose gateway, rpc ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/celestiaorg/celestia-app:v1.6.0 AS celestia-app
 
-FROM ghcr.io/rollkit/celestia-da:49633a0
+FROM ghcr.io/rollkit/celestia-da:v0.12.1-rc3
 
 USER root
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,5 +83,7 @@ celestia-da bridge start \
   --node.store $NODE_PATH --gateway \
   --core.ip 127.0.0.1 \
   --keyring.accname validator \
+  --gateway.addr 0.0.0.0 \
+  --rpc.addr 0.0.0.0 \
   --da.grpc.namespace "$CELESTIA_NAMESPACE" \
   --da.grpc.listen "0.0.0.0:26650"


### PR DESCRIPTION
## Overview

This PR updates the `entrypoint.sh` script to expose gateway, rpc ports as celestia-node `v0.12.2` defaults to the loopback interface by default.

While here, bump celestia-da to `v0.12.1-rc3`

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application base image to a newer version for enhanced stability and performance.
  - Improved network configuration with new gateway and RPC address settings for better connectivity and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->