### PR TITLE
docker: bump celestia-da to v0.12.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/celestiaorg/celestia-app:v1.6.0 AS celestia-app
 
-FROM ghcr.io/rollkit/celestia-da:v0.12.1-rc3
+FROM ghcr.io/rollkit/celestia-da:v0.12.6
 
 USER root
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,8 +33,8 @@ celestia-appd collect-gentxs
 # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
 # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.celestia-app/config/config.toml
-sed -i'.bak' 's/^timeout_commit\s*=.*/timeout_commit = "1s"/g' ~/.celestia-app/config/config.toml
-sed -i'.bak' 's/^timeout_propose\s*=.*/timeout_propose = "1s"/g' ~/.celestia-app/config/config.toml
+sed -i'.bak' 's/^timeout_commit\s*=.*/timeout_commit = "2s"/g' ~/.celestia-app/config/config.toml
+sed -i'.bak' 's/^timeout_propose\s*=.*/timeout_propose = "2s"/g' ~/.celestia-app/config/config.toml
 sed -i'.bak' 's/index_all_keys = false/index_all_keys = true/g' ~/.celestia-app/config/config.toml
 sed -i'.bak' 's/mode = "full"/mode = "validator"/g' ~/.celestia-app/config/config.toml
 


### PR DESCRIPTION
## Overview

This PR updates celestia-da to v0.12.6

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the application to use a newer base image for enhanced stability and performance.
  
- **Improvements**
	- Increased timeout settings for commit and propose actions to improve reliability during network operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->